### PR TITLE
Upgraded dependency on Map::Tube v3.62.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,7 @@ name 'Map-Tube-Malaga';
 readme_from 'Malaga.pm';
 recursive_author_tests('xt');
 requires 'File::Share' => 0;
-requires 'Map::Tube' => '3.10';
+requires 'Map::Tube' => '3.62';
 requires 'Moo' => 0;
 requires 'namespace::clean' => 0;
 requires 'perl' => '5.8.0';


### PR DESCRIPTION
Hi @tupinek,

Please review the PR.
It propose upgrading dependency on latest Map::Tube to import recent changes.

Many Thanks.
Best Regards,
Mohammad S Anwar
